### PR TITLE
Lexer Fix

### DIFF
--- a/Formatter/src/test/kotlin/OperationRuleTest.kt
+++ b/Formatter/src/test/kotlin/OperationRuleTest.kt
@@ -163,7 +163,7 @@ class OperationRuleTest {
     @Test
     fun test009isRuleValid() {
         val operationRule = rules.OperationRule()
-        val result = operationRule.isTheRuleIncluded(mapOf())
+        val result = operationRule.isTheRuleIncluded()
         assertTrue(result is rules.OperationRule)
     }
 
@@ -171,14 +171,14 @@ class OperationRuleTest {
     fun test010EnforceRule() {
         val operationRule = rules.OperationRule()
 
-        val result = operationRule.isTheRuleIncluded(mapOf()).enforceRule("3+3")
+        val result = operationRule.isTheRuleIncluded().enforceRule("3+3")
         assertEquals("3 + 3", result)
     }
 
     @Test
     fun test011EnforceRule() {
         val operationRule = rules.OperationRule()
-        val result = operationRule.isTheRuleIncluded(mapOf()).enforceRule("3+3+3")
+        val result = operationRule.isTheRuleIncluded().enforceRule("3+3+3")
         assertEquals("3 + 3 + 3", result)
     }
 }

--- a/Interpreter/src/test/kotlin/DeclarationExecutorTest.kt
+++ b/Interpreter/src/test/kotlin/DeclarationExecutorTest.kt
@@ -1,6 +1,6 @@
 import astn.VarDeclaration
+import executors.DeclarationExecution
 import interpreter.Value
-import interpreter.executors.DeclarationExecution
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
 import token.DataType

--- a/Lexer/src/main/kotlin/lexer/Lexer.kt
+++ b/Lexer/src/main/kotlin/lexer/Lexer.kt
@@ -1,5 +1,6 @@
 package org.example.lexer
 
+import token.DataType
 import token.Token
 
 /**
@@ -15,8 +16,14 @@ class Lexer(private val tokenGenerator: List<RegexTokenGenerator>) : LexerInterf
     ): List<Token> {
         val tokens = mutableListOf<Token>()
         tokenGenerator.forEach { tokenGenerator ->
-            val token = tokenGenerator.generateToken(line, numberLine)
-            tokens.addAll(token)
+            val generatedTokens = tokenGenerator.generateToken(line, numberLine)
+            if (generatedTokens.isNotEmpty()) {
+                tokens.addAll(generatedTokens)
+            }
+        }
+
+        if (tokens.isEmpty()) {
+            tokens.add(Token(DataType.ERROR, line, Pair(0, numberLine), Pair(line.length - 1, numberLine)))
         }
         return tokens
     }

--- a/Lexer/src/main/kotlin/lexer/TemporalLexer.kt
+++ b/Lexer/src/main/kotlin/lexer/TemporalLexer.kt
@@ -33,8 +33,7 @@ class TemporalLexer {
                 RegexTokenGenerator("\\bnumber\\b", DataType.NUMBER_TYPE, true),
                 RegexTokenGenerator("\\bstring\\b", DataType.STRING_TYPE, true),
                 RegexTokenGenerator("\\b\\d+\\.?\\d*\\b", DataType.NUMBER_VALUE, false),
-                RegexTokenGenerator("\\b[a-zA-Z_][a-zA-Z0-9_]*\\b", DataType.VARIABLE_NAME, false),
-                RegexTokenGenerator("\\w+", DataType.ERROR, false),
+                RegexTokenGenerator("(?<!\")\\b[a-zA-Z_][a-zA-Z0-9_]*\\b(?!\")", DataType.VARIABLE_NAME, false),
             ),
         )
 

--- a/Lexer/src/test/kotlin/token/LexerTest.kt
+++ b/Lexer/src/test/kotlin/token/LexerTest.kt
@@ -133,10 +133,11 @@ class LexerTest {
         assertEquals(DataType.STRING_VALUE, tokens[3].getType())
         assertEquals("\"value\"", tokens[3].getValue())
     }
-   /* @Test
-    fun testWithStringValue() { //Variable name se confunde. Tambien hay problema con el "Hello"
+
+    @Test
+    fun testWithStringValue() { // Variable name se confunde. Tambien hay problema con el "Hello"
         val lexer = TemporalLexer()
-        val tokens = lexer.lex("let x: String = \"Hello\";", 1)
+        val tokens = lexer.lex("let x: string = \"Hello\";", 1)
         assertEquals(DataType.DECLARATION_VARIABLE, tokens[0].getType())
         assertEquals(DataType.VARIABLE_NAME, tokens[1].getType())
         assertEquals("x", tokens[1].getValue())
@@ -145,7 +146,7 @@ class LexerTest {
         assertEquals(DataType.ASSIGNATION, tokens[4].getType())
         assertEquals(DataType.STRING_VALUE, tokens[5].getType())
         assertEquals("\"Hello\"", tokens[5].getValue())
-    }*/
+    }
 
     @Test
     fun testStringWithEscapedCharacters() {


### PR DESCRIPTION
Lexer tokens no longer appear twice for Strings.
Previous case:
let name:string = "Hello";
would make a token String value for "Hello" and a token variable name for Hello
Error tokens are now thrown when tokens are empty.