### PR TITLE
String print fix

### DIFF
--- a/Formatter/src/main/kotlin/rules/OperationRule.kt
+++ b/Formatter/src/main/kotlin/rules/OperationRule.kt
@@ -65,7 +65,7 @@ class OperationRule(val enforcer: List<Enforcer> = listOf()) {
             }
 
             is OperationNumber -> postfixAST.value.getValue()
-            is OperationString -> postfixAST.value.getValue()
+            is OperationString -> "\"" + postfixAST.value.getValue() + "\""
             is OperationVariable -> postfixAST.value.getValue()
             else -> throw IllegalArgumentException("Invalid OpTree type")
         }

--- a/Formatter/src/test/kotlin/FormatterImplTest.kt
+++ b/Formatter/src/test/kotlin/FormatterImplTest.kt
@@ -22,7 +22,7 @@ class FormatterImplTest {
                 OperationString(
                     Token(
                         DataType.STRING_VALUE,
-                        "\"Hello\"",
+                        "Hello",
                         Pair(7, 0),
                         Pair(12, 0),
                     ),
@@ -44,7 +44,7 @@ class FormatterImplTest {
                     Token(DataType.NUMBER_TYPE, "number", Pair(0, 0), Pair(4, 0)),
                     Token(DataType.VARIABLE_NAME, "dong", Pair(5, 0), Pair(8, 0)),
                 ),
-                OperationString(Token(DataType.STRING_VALUE, "\"Hola\"", Pair(12, 0), Pair(15, 0))),
+                OperationString(Token(DataType.STRING_VALUE, "Hola", Pair(12, 0), Pair(15, 0))),
             )
         val map: MutableMap<String, Any> = HashMap()
         map["DotFront"] = 1

--- a/Formatter/src/test/kotlin/MethodRuleTest.kt
+++ b/Formatter/src/test/kotlin/MethodRuleTest.kt
@@ -33,7 +33,7 @@ class MethodRuleTest {
         val ast =
             astn.Method(
                 Token(DataType.VARIABLE_NAME, "println", Pair(0, 0), Pair(6, 0)),
-                OperationString(Token(DataType.STRING_VALUE, "\"Hello\"", Pair(7, 0), Pair(12, 0))),
+                OperationString(Token(DataType.STRING_VALUE, "Hello", Pair(7, 0), Pair(12, 0))),
             )
         val methodRule: Rules = MethodRule("ammountOfLines")
 

--- a/Formatter/src/test/kotlin/OperationRuleTest.kt
+++ b/Formatter/src/test/kotlin/OperationRuleTest.kt
@@ -91,7 +91,7 @@ class OperationRuleTest {
             listOf(
                 Token(DataType.METHOD_CALL, "println", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.STRING_VALUE, "\"Hello\"", Pair(4, 0), Pair(5, 0)),
+                Token(DataType.STRING_VALUE, "Hello", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.NUMBER_VALUE, "3", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
@@ -125,7 +125,7 @@ class OperationRuleTest {
             listOf(
                 Token(DataType.METHOD_CALL, "println", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.STRING_VALUE, "\"Hello\"", Pair(4, 0), Pair(5, 0)),
+                Token(DataType.STRING_VALUE, "Hello", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.VARIABLE_NAME, "x", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.RIGHT_PARENTHESIS, ")", Pair(4, 0), Pair(5, 0)),
@@ -142,7 +142,7 @@ class OperationRuleTest {
             listOf(
                 Token(DataType.METHOD_CALL, "println", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.LEFT_PARENTHESIS, "(", Pair(4, 0), Pair(5, 0)),
-                Token(DataType.STRING_VALUE, "\"Hello\"", Pair(4, 0), Pair(5, 0)),
+                Token(DataType.STRING_VALUE, "Hello", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.VARIABLE_NAME, "x", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.OPERATOR_PLUS, "+", Pair(4, 0), Pair(5, 0)),

--- a/Formatter/src/test/kotlin/VarDeclarationAssignationRuleTest.kt
+++ b/Formatter/src/test/kotlin/VarDeclarationAssignationRuleTest.kt
@@ -41,7 +41,7 @@ class VarDeclarationAssignationRuleTest {
                     Token(DataType.NUMBER_TYPE, "number", Pair(0, 0), Pair(4, 0)),
                     Token(DataType.VARIABLE_NAME, "dong", Pair(5, 0), Pair(8, 0)),
                 ),
-                OperationString(Token(DataType.STRING_VALUE, "\"Hola\"", Pair(12, 0), Pair(15, 0))),
+                OperationString(Token(DataType.STRING_VALUE, "Hola", Pair(12, 0), Pair(15, 0))),
             )
         val expectedCode = "let dong:number=\"Hola\";"
         assertEquals(expectedCode, varDeclarationAssignationRule.genericLine(ast))
@@ -63,7 +63,7 @@ class VarDeclarationAssignationRuleTest {
                     Token(DataType.NUMBER_TYPE, "number", Pair(0, 0), Pair(4, 0)),
                     Token(DataType.VARIABLE_NAME, "dong", Pair(5, 0), Pair(8, 0)),
                 ),
-                OperationString(Token(DataType.STRING_VALUE, "\"Hola\"", Pair(12, 0), Pair(15, 0))),
+                OperationString(Token(DataType.STRING_VALUE, "Hola", Pair(12, 0), Pair(15, 0))),
             )
         val expectedCode = "let dong : number = \"Hola\";"
         assertEquals(

--- a/Lexer/src/main/kotlin/lexer/LexerImpl.kt
+++ b/Lexer/src/main/kotlin/lexer/LexerImpl.kt
@@ -1,5 +1,6 @@
 package lexer
 
+import lexer.tokenRule.StringRule
 import org.example.lexer.Lexer
 import org.example.lexer.ListTokenManager
 import org.example.lexer.RegexTokenGenerator
@@ -17,6 +18,8 @@ class LexerImpl(private val tokenRules: Map<String, TokenRegexRule> = mapOf()) :
         tokenRules.map { (_, rule) ->
             if (rule.getType() == DataType.METHOD_CALL) {
                 RegexTokenGenerator(rule, MethodCallRule())
+            } else if (rule.getType() == DataType.STRING_VALUE) {
+                RegexTokenGenerator(rule, StringRule())
             } else {
                 RegexTokenGenerator(rule)
             }

--- a/Lexer/src/main/kotlin/lexer/tokenRule/StringRule.kt
+++ b/Lexer/src/main/kotlin/lexer/tokenRule/StringRule.kt
@@ -1,0 +1,21 @@
+package lexer.tokenRule
+
+import token.DataType
+import token.Token
+
+class StringRule() : TokenRule {
+    override fun generateToken(
+        type: DataType,
+        value: String,
+        initialPosition: Pair<Int, Int>,
+        finalPosition: Pair<Int, Int>,
+    ): Token? {
+        val newValue: String = value.substring(1, value.length - 1)
+
+        return Token(type, newValue, initialPosition, finalPosition)
+    }
+
+    override fun getTypes(): List<DataType> {
+        return listOf(DataType.STRING_VALUE)
+    }
+}

--- a/Lexer/src/test/kotlin/token/LexerImplTest.kt
+++ b/Lexer/src/test/kotlin/token/LexerImplTest.kt
@@ -158,7 +158,7 @@ class LexerImplTest {
         assertEquals("varName", tokens[1].getValue())
         assertEquals(DataType.ASSIGNATION, tokens[2].getType())
         assertEquals(DataType.STRING_VALUE, tokens[3].getType())
-        assertEquals("\"value\"", tokens[3].getValue())
+        assertEquals("value", tokens[3].getValue())
     }
 
     @Test
@@ -172,7 +172,7 @@ class LexerImplTest {
         assertEquals(DataType.STRING_TYPE, tokens[3].getType())
         assertEquals(DataType.ASSIGNATION, tokens[4].getType())
         assertEquals(DataType.STRING_VALUE, tokens[5].getType())
-        assertEquals("\"Hello\"", tokens[5].getValue())
+        assertEquals("Hello", tokens[5].getValue())
     }
 
     @Test
@@ -180,7 +180,7 @@ class LexerImplTest {
         val lexerImpl: Lexer = LexerImpl(tokenRulesMap)
         val tokens = lexerImpl.lex("\"Line1\\nLine2\";", 1)
         assertEquals(DataType.STRING_VALUE, tokens[0].getType())
-        assertEquals("\"Line1\\nLine2\"", tokens[0].getValue())
+        assertEquals("Line1\\nLine2", tokens[0].getValue())
     }
 
     @Test

--- a/Lexer/src/test/kotlin/token/LexerImplTest.kt
+++ b/Lexer/src/test/kotlin/token/LexerImplTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class LexerImplTest {
-    val tokenRulesMap: Map<String, TokenRegexRule> =
+    private val tokenRulesMap: Map<String, TokenRegexRule> =
         mapOf(
             "STRING_VALUE" to TokenRegexRule("\"(?:\\\\.|[^\"])*\"", DataType.STRING_VALUE, false),
             "DECLARATION_VARIABLE" to TokenRegexRule("\\blet\\b", DataType.DECLARATION_VARIABLE, true),

--- a/PrintScript/src/test/kotlin/PrintScriptTest.kt
+++ b/PrintScript/src/test/kotlin/PrintScriptTest.kt
@@ -64,7 +64,7 @@ class PrintScriptTest {
                 "490\n" +
                 "405\n" +
                 "67\n" +
-                "\"Hola\"\" \"\"Mundo\"\n" +
+                "Hola Mundo\n" +
                 "12250\n" +
                 "0\n" +
                 "12250\n" +
@@ -74,12 +74,12 @@ class PrintScriptTest {
                 "199900\n" +
                 "499\n" +
                 "-997501\n" +
-                "\"Prueba\"\" \"\"Lexer\"\n" +
-                "\"Parser\"\" \"\"Interpreter\"\n" +
-                "\"Prueba\"\" \"\"Lexer\"\"\"\"Parser\"\" \"\"Interpreter\"\n" +
+                "Prueba Lexer\n" +
+                "Parser Interpreter\n" +
+                "Prueba LexerParser Interpreter\n" +
                 "-497553099\n" +
                 "1988150668\n" +
-                "\"PucaQuiereaGaru\"-4975530991988150668\n" +
+                "PucaQuiereaGaru-4975530991988150668\n" +
                 "-1492051991\n" +
                 "-1492053744\n"
         assertEquals(expected, printScript.start(path))
@@ -108,7 +108,7 @@ class PrintScriptTest {
     fun test008ApostropheString() {
         val printScript = PrintScript()
         val path = "src/test/resources/apostropheStringTest.txt"
-        val expectedOutput = "'Hello World!'\n"
+        val expectedOutput = "Hello World!\n"
         assertEquals(expectedOutput, printScript.start(path))
     }
 }


### PR DESCRIPTION
[String print fix. Change the generation of a Token of Type String. It
 will generate de Token value without the enclosure character.