### PR TITLE
stored variables are now saved in PrintScript module

### DIFF
--- a/Interpreter/src/main/kotlin/Interpreter.kt
+++ b/Interpreter/src/main/kotlin/Interpreter.kt
@@ -3,5 +3,8 @@ package interpreter
 import astn.AST
 
 interface Interpreter {
-    fun readAST(ast: AST): String
+    fun readAST(
+        ast: AST,
+        storedVariables: MutableMap<String, Value>,
+    ): String
 }

--- a/Interpreter/src/main/kotlin/InterpreterImpl.kt
+++ b/Interpreter/src/main/kotlin/InterpreterImpl.kt
@@ -22,15 +22,16 @@ import interpreter.executors.MethodExecutor
  * @throws Exception If the AST is of an unexpected type.
  */
 class InterpreterImpl : Interpreter {
-    private val variables = mutableMapOf<String, Value>()
-
-    override fun readAST(ast: AST): String {
+    override fun readAST(
+        ast: AST,
+        storedVariables: MutableMap<String, Value>,
+    ): String {
         return when (ast) {
             is EmptyAST -> ""
-            is Assignation -> AssignationExecution().execute(ast, variables)
-            is VarDeclaration -> DeclarationExecution().execute(ast, variables)
-            is VarDeclarationAssignation -> DeclarationAssignationExecution().execute(ast, variables)
-            is Method -> MethodExecutor().execute(ast, variables)
+            is Assignation -> AssignationExecution().execute(ast, storedVariables)
+            is VarDeclaration -> DeclarationExecution().execute(ast, storedVariables)
+            is VarDeclarationAssignation -> DeclarationAssignationExecution().execute(ast, storedVariables)
+            is Method -> MethodExecutor().execute(ast, storedVariables)
             else -> throw Exception("Unexpected structure")
         }
     }

--- a/Interpreter/src/test/kotlin/InterpreterTest.kt
+++ b/Interpreter/src/test/kotlin/InterpreterTest.kt
@@ -5,6 +5,7 @@ import astn.OperationVariable
 import astn.VarDeclaration
 import astn.VarDeclarationAssignation
 import interpreter.InterpreterImpl
+import interpreter.Value
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import token.DataType
@@ -20,7 +21,8 @@ class InterpreterTest {
                 Token(DataType.NUMBER_TYPE, "number", Pair(4, 0), Pair(5, 0)),
                 Token(DataType.VARIABLE_NAME, "x", Pair(0, 0), Pair(1, 0)),
             )
-        val result = interpreter.readAST(ast)
+        val variables = mutableMapOf<String, Value>()
+        val result = interpreter.readAST(ast, variables)
         assertEquals("", result)
     }
 
@@ -35,10 +37,11 @@ class InterpreterTest {
                 ),
                 OperationString(Token(DataType.STRING_VALUE, "Hola", Pair(12, 0), Pair(15, 0))),
             )
+        val variables = mutableMapOf<String, Value>()
 
         val exception =
             assertThrows<Exception> {
-                interpreter.readAST(ast)
+                interpreter.readAST(ast, variables)
             }
 
         assertEquals("Type Mismatch at Line 0", exception.message)
@@ -53,8 +56,9 @@ class InterpreterTest {
                 Token(DataType.NUMBER_TYPE, "number", Pair(0, 0), Pair(4, 0)),
                 Token(DataType.VARIABLE_NAME, "a", Pair(5, 0), Pair(6, 0)),
             )
+        val variables = mutableMapOf<String, Value>()
 
-        assertEquals("", interpreter.readAST(ast2))
+        assertEquals("", interpreter.readAST(ast2, variables))
         // Cambialo al error que aparece
     }
 
@@ -66,7 +70,8 @@ class InterpreterTest {
                 Token(DataType.VARIABLE_NAME, "println", Pair(0, 0), Pair(6, 0)),
                 OperationString(Token(DataType.STRING_VALUE, "Hello", Pair(7, 0), Pair(12, 0))),
             )
-        val result = interpreter.readAST(ast)
+        val variables = mutableMapOf<String, Value>()
+        val result = interpreter.readAST(ast, variables)
         assertEquals("Hello\n", result)
     }
 
@@ -83,10 +88,12 @@ class InterpreterTest {
                 Token(DataType.NUMBER_TYPE, "number", Pair(0, 0), Pair(4, 0)),
                 Token(DataType.VARIABLE_NAME, "x", Pair(5, 0), Pair(6, 0)),
             )
-        interpreter.readAST(ast)
+        val variables = mutableMapOf<String, Value>()
+
+        interpreter.readAST(ast, variables)
         val exception =
             assertThrows<Exception> {
-                interpreter.readAST(ast2)
+                interpreter.readAST(ast2, variables)
             }
         assertEquals("Variable Already Exists at Line 0", exception.message)
     }
@@ -110,10 +117,12 @@ class InterpreterTest {
                 ),
                 OperationNumber(Token(DataType.NUMBER_VALUE, "5", Pair(7, 0), Pair(8, 0))),
             )
-        interpreter.readAST(ast)
+        val variables = mutableMapOf<String, Value>()
+
+        interpreter.readAST(ast, variables)
         val exception =
             assertThrows<Exception> {
-                interpreter.readAST(ast2)
+                interpreter.readAST(ast2, variables)
             }
         assertEquals("Variable Already Exists at Line 0", exception.message)
     }
@@ -134,8 +143,10 @@ class InterpreterTest {
                 ),
                 OperationNumber(Token(DataType.NUMBER_VALUE, "5", Pair(7, 0), Pair(8, 0))),
             )
-        interpreter.readAST(ast2)
-        val result = interpreter.readAST(ast)
+        val variables = mutableMapOf<String, Value>()
+
+        interpreter.readAST(ast2, variables)
+        val result = interpreter.readAST(ast, variables)
         assertEquals("5\n", result)
     }
 }

--- a/PrintScript/src/main/kotlin/PrintScript.kt
+++ b/PrintScript/src/main/kotlin/PrintScript.kt
@@ -6,6 +6,7 @@ import formatter.FormatterImpl
 import impl.ParserImpl
 import interfaces.Parser
 import interpreter.InterpreterImpl
+import interpreter.Value
 import lexer.LexerImpl
 import lexer.TokenRegexRule
 import rules.AssignationRule
@@ -38,8 +39,10 @@ class PrintScript {
             ),
         )
 
+    private val storedVariables = mutableMapOf<String, Value>()
+
     fun start(path: String): String {
-        return processFile(path) { line, numberLine -> interpreter.readAST(lexAndParse(line, numberLine)) }
+        return processFile(path) { line, numberLine -> interpreter.readAST(lexAndParse(line, numberLine), storedVariables) }
     }
 
     fun format(path: String): String {


### PR DESCRIPTION
Store Variables are moved to the print script module, with the objective of making Interpreter inmutable. It recieves a mutable map now.